### PR TITLE
set 0600 (octal) mode for config and vault files

### DIFF
--- a/src/lib/Config.py
+++ b/src/lib/Config.py
@@ -64,6 +64,7 @@ class Config:
 
         with open(self.configPath, 'w') as configfile:
            self.config.write(configfile)
+        os.chmod(self.configPath, 0o600)
 
     def generateRandomSalt(self):
         """

--- a/src/lib/ImportExport.py
+++ b/src/lib/ImportExport.py
@@ -1,5 +1,5 @@
 
-import os, sys, json
+import sys, json
 
 """
     Adding import or export formats:

--- a/src/lib/Vault.py
+++ b/src/lib/Vault.py
@@ -1,5 +1,5 @@
 
-import getpass, json, base64, time, sys
+import getpass, json, base64, time, sys, os
 
 from Crypto.Cipher import AES
 from Crypto.Hash import SHA256
@@ -160,6 +160,7 @@ class Vault:
             [ f.write(x) for x in (cipher.nonce, tag, ciphertext) ]
         finally:
             f.close()
+        os.chmod(self.vaultPath, 0o600)
 
     @setAutoLockTimer # Set auto lock timer (to prevent immediate re-locking)
     def openVault(self):

--- a/src/vault.py
+++ b/src/vault.py
@@ -2,10 +2,10 @@ import os
 
 import argparse
 
-from vault.lib.Vault import Vault
-from vault.lib.Config import Config
-from vault.lib.ImportExport import ImportExport
-from vault.lib.Misc import *
+from .lib.Vault import Vault
+from .lib.Config import Config
+from .lib.ImportExport import ImportExport
+from .lib.Misc import *
 
 # Parse arguments
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
- for increased security, change default file mask to be readable/writable
  only by owner when creating config and vault files