### PR TITLE
Search floats as strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except(IOError, ImportError):
 
 setup(
     name='pyvault',
-    version='1.8.1',
+    version='1.8.2',
     description='Python password manager',
     long_description=long_description,
     author='Gabriel Bordeaux',

--- a/src/lib/Vault.py
+++ b/src/lib/Vault.py
@@ -553,7 +553,7 @@ class Vault:
 
         if self.vault.get('secrets'):
             # Check if the user inputed an item number
-            if self.isNumeric(search):
+            if search.isdigit():
                 # Get item
                 try:
                     self.vault['secrets'][int(search)]  # Will return an IndexError if the item does not exists
@@ -1006,17 +1006,3 @@ class Vault:
             return u'\U0001F511  '  # Extra spaces are intentional
 
         return ''
-
-    def isNumeric(self, item):
-        """
-            Check if a string contains numbers only
-            `123` -> `True`
-            `test` -> `False`
-            `test123` -> `False`
-        """
-
-        try:
-            float(item)
-            return True
-        except ValueError:
-            return False


### PR DESCRIPTION
**Fixes the following error:**

```
Enter search: 53.
Traceback (most recent call last):
  File "/usr/local/bin/vault", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/vault/vault.py", line 105, in main
    v.unlock()
  File "/usr/local/lib/python3.6/site-packages/vault/lib/Vault.py", line 141, in unlock
    self.menu()
  File "/usr/local/lib/python3.6/site-packages/vault/lib/Vault.py", line 298, in menu
    nextCommand = self.search()
  File "/usr/local/lib/python3.6/site-packages/vault/lib/Vault.py", line 559, in search
    self.vault['secrets'][int(search)]  # Will return an IndexError if the item does not exists
ValueError: invalid literal for int() with base 10: '53.'
```

**Previous behavior:**

`52` -> search as a secret key
`52.` -> search as a secret key (will not work since they are integer)
`abc.` -> search as name/login string

**New behavior:**

`52` -> search as a secret key (unchanged)
`52.` -> search as name/login string
`abc.` -> search as name/login string (unchanged)
