### PR TITLE
Stop timer and cancel if clipboard content has changed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except(IOError, ImportError):
 
 setup(
     name='pyvault',
-    version='1.8.2',
+    version='1.8.3',
     description='Python password manager',
     long_description=long_description,
     author='Gabriel Bordeaux',


### PR DESCRIPTION
While an item is in the clipboard, its hash will be checked every second against the hash of the item initially put in the clipboard.

If the clipboard content is changed, the timer will stop and the clipboard will not be emptied.