### PR TITLE
CSV functionality, and KeePassXC compliance

### DIFF
--- a/src/vault.py
+++ b/src/vault.py
@@ -152,7 +152,7 @@ def main():
     parser.add_argument("-x", "--export", type=str,
                         help="File to export credentials to")
     parser.add_argument("-f", "--file_format", type=str, help="Import/export file format (default: 'json')",
-                        choices=['json'], nargs='?', default='json')
+                        choices=['csv', 'json'], nargs='?', default='json')
     parser.add_argument("-e", "--erase_vault", action='store_true',
                         help="Erase the vault and config file")
     args = parser.parse_args()

--- a/src/views/categories.py
+++ b/src/views/categories.py
@@ -140,6 +140,11 @@ def add_input():
     if not name:
         return False
 
+    # No slashes in category names (see: KeePassXC csv protocol)
+    if '/' in name:
+        print('ERROR: cannot have "/" character in category name')
+        return False
+
     # Create category
     result = add(name=name)
 

--- a/vault
+++ b/vault
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+import sys
+
+from src import vault
+
+vault.main()


### PR DESCRIPTION
- added CSV exporting/importing capabilities (in KePassXC format)

- added executable `vault` script in root (for testing purposes)

**NOTE:** the command line still requires the `-f` flag be passed in _before_ the  `-i {file_name.ext}` flag, which isn't always intuitive