### PR TITLE
Replace pysqlcipher3 with sqlcipher3

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Vault 2.x requires `sqlcipher` to be installed on your machine.
 On MacOS, you can install it with [brew](https://brew.sh/):
 ```bash
 brew install sqlcipher
+
+# Install sqlcipher3
+pip3 install sqlcipher3==0.4.5
+
+# If you are getting an error "Failed to build sqlcipher3", you would need to fix the build flags:
+SQLCIPHER_PATH="$(brew --cellar sqlcipher)/$(brew list --versions sqlcipher | tr ' ' '\n' | tail -1)"
+C_INCLUDE_PATH=$SQLCIPHER_PATH/include LIBRARY_PATH=$SQLCIPHER_PATH/lib pip3 install sqlcipher3==0.4.5
 ```
 
 On Ubuntu/Debian, you can install it with apt-get:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     package_dir={'vault': 'src'},
     install_requires=['pycryptodome==3.9.9', 'pyperclip', 'tabulate',
                       'argparse', 'passwordgenerator', 'SQLAlchemy==1.3.22',
-                      'pysqlcipher3'],  # external dependencies
+                      'sqlcipher3==0.4.5'],  # external dependencies
     entry_points={
         'console_scripts': [
             'vault = vault.vault:main',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except(IOError, ImportError):
 
 setup(
     name='pyvault',
-    version='2.3.4',
+    version='2.4',
     description='Python password manager',
     long_description=long_description,
     author='Gabriel Bordeaux',

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -62,7 +62,7 @@ def get_engine(encrypted=True):
         raise RuntimeError('`db_file` is not defined in the global scope')
 
     if encrypted:
-        return create_engine('sqlite+pysqlcipher://:' + get_db_key() + '@' + get_slashes() + global_scope['db_file'])
+        return create_engine('sqlite+sqlcipher3://:' + get_db_key() + '@' + get_slashes() + global_scope['db_file'])
     else:
         return create_engine('sqlite:' + get_slashes() + global_scope['db_file'])
 

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -2,6 +2,7 @@ import os
 from hashlib import sha256
 
 
+import sqlcipher3
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import as_declarative
 from sqlalchemy.orm import Session
@@ -62,7 +63,7 @@ def get_engine(encrypted=True):
         raise RuntimeError('`db_file` is not defined in the global scope')
 
     if encrypted:
-        return create_engine('sqlite+sqlcipher3://:' + get_db_key() + '@' + get_slashes() + global_scope['db_file'])
+        return create_engine('sqlite+pysqlcipher://:' + get_db_key() + '@' + get_slashes() + global_scope['db_file'], module=sqlcipher3)
     else:
         return create_engine('sqlite:' + get_slashes() + global_scope['db_file'])
 


### PR DESCRIPTION
Can be tested with:
```
git clone https://github.com/gabfl/vault && cd vault && git fetch origin sqlcipher3-sqlite && git checkout sqlcipher3-sqlite
pip3.9 install .
```

Resolves https://github.com/gabfl/vault/issues/58