### PR TITLE
Bump version, add Python 3.11 and 3.12 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --yes gcc python3-dev libsqlcipher-dev
+          sudo apt-get install --yes gcc python3-dev python3-setuptools libsqlcipher-dev
           pip install -U pip
           pip install pycodestyle coverage pytest
           python3 setup.py install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --yes gcc python3-dev python3-setuptools libsqlcipher-dev
+          sudo apt-get install --yes gcc python3-dev libsqlcipher-dev
           pip install -U pip
-          pip install pycodestyle coverage pytest
+          pip install pycodestyle coverage pytest setuptools
           python3 setup.py install
       - name: Run pycodestyle
         run: |

--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ On MacOS, you can install `sqlcipher` with [brew](https://brew.sh/):
 brew install sqlcipher
 
 # Install sqlcipher3
-pip3 install sqlcipher3==0.4.5
+SQLCIPHER_VERSION="0.5.3"
+pip3 install sqlcipher3==$SQLCIPHER_VERSION
 
 # If you are getting an error "Failed to build sqlcipher3", you would need to fix the build flags:
 SQLCIPHER_PATH="$(brew --cellar sqlcipher)/$(brew list --versions sqlcipher | tr ' ' '\n' | tail -1)"
-C_INCLUDE_PATH=$SQLCIPHER_PATH/include LIBRARY_PATH=$SQLCIPHER_PATH/lib pip3 install sqlcipher3==0.4.5
+C_INCLUDE_PATH=$SQLCIPHER_PATH/include LIBRARY_PATH=$SQLCIPHER_PATH/lib pip3 install sqlcipher3==$SQLCIPHER_VERSION
 ```
 
 Then install the vault:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'tabulate',
         'passwordgenerator',
         'SQLAlchemy==1.4.41',
-        'sqlcipher3==0.4.5'
+        'sqlcipher3==0.5.3'
     ],  # external dependencies
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except (IOError, ImportError):
 
 setup(
     name='pyvault',
-    version='2.4.4',
+    version='2.4.5',
     description='Python password manager',
     long_description=long_description,
     author='Gabriel Bordeaux',


### PR DESCRIPTION
 - Bump version to `2.4.5`
 - Bumped dependency `sqlcipher3` from `0.4.5` to `0.5.3`
 - add Python 3.11 and 3.12 to test matrix
